### PR TITLE
Nginx refactor

### DIFF
--- a/nginx-configparser/config_parser.cc
+++ b/nginx-configparser/config_parser.cc
@@ -29,7 +29,6 @@ bool NginxConfig::find(const std::string& key, std::string& value, int depth) {
   // Finds the depth instance of the key from the root level config. 
   // Expects a string to be the second value, and returns that.
   // Returns true if and only if the statement is found. 
-  printf("Didn't enter mock method");
   for(const auto& statement : statements_) {
     if (statement->tokens_[0].compare(key) == 0) {
       if(statement->tokens_.size() > depth) {
@@ -41,23 +40,31 @@ bool NginxConfig::find(const std::string& key, std::string& value, int depth) {
   return false;
 }
 
-// bool NginxConfig::find(const std::string& key, NginxConfig& value) {
-//   // Finds the first instance of the string from the root level config. 
-//   // Expects a config token to be the second value, and returns that.
-//   for(const auto& statement : statements_) {
-//     if (statement->tokens_[0].compare(key) == 0) {
-//       if(statement->child_block_.get() != nullptr) {
-//           value = *statement->child_block_;
-//           return true;
-//       }
-//       else {
-//         return false;
-//       }
-      
-//     }
-//   }
-//   return false;
-// }
+bool NginxConfig::find(const std::string& key, NginxConfig& value) {
+  // Finds the first instance of the string from the root level config. 
+  // Expects a config token to be the second value, and returns that.
+  for(const auto& statement : statements_) {
+    if (statement->tokens_[0].compare(key) == 0) {
+      if(statement->child_block_.get() != nullptr) {
+          value = *statement->child_block_;
+          return true;
+      } else {
+        printf("Error: no sub-config!");
+      }
+    }
+  }
+  return false;
+}
+
+std::vector<std::shared_ptr<NginxConfigStatement> > NginxConfig::findAll(const std::string& key) {
+  std::vector<std::shared_ptr<NginxConfigStatement> > ret_statements;
+  for(const auto statement : statements_) {
+    if (statement.get()->tokens_[0].compare(key) == 0) {
+      ret_statements.emplace_back(statement);
+    }
+  }
+  return ret_statements;
+}
 
 std::string NginxConfigStatement::ToString(int depth) {
   std::string serialized_statement;

--- a/nginx-configparser/config_parser.cc
+++ b/nginx-configparser/config_parser.cc
@@ -25,18 +25,39 @@ std::string NginxConfig::ToString(int depth) {
   return serialized_config;
 }
 
-bool NginxConfig::find(std::string& s) {
-  // TODO: fix this
-  // Finds the first instance of the string. This isn't quite correct, 
-  // instead it should find the port in the root level config.
+bool NginxConfig::find(const std::string& key, std::string& value, int depth) {
+  // Finds the depth instance of the key from the root level config. 
+  // Expects a string to be the second value, and returns that.
+  // Returns true if and only if the statement is found. 
+  printf("Didn't enter mock method");
   for(const auto& statement : statements_) {
-    if (statement->tokens_[0].compare(s) == 0) {
-      s = statement->tokens_[1];
-      return true;
+    if (statement->tokens_[0].compare(key) == 0) {
+      if(statement->tokens_.size() > depth) {
+        value = statement->tokens_[depth];
+        return true;
+      }
     }
   }
   return false;
 }
+
+// bool NginxConfig::find(const std::string& key, NginxConfig& value) {
+//   // Finds the first instance of the string from the root level config. 
+//   // Expects a config token to be the second value, and returns that.
+//   for(const auto& statement : statements_) {
+//     if (statement->tokens_[0].compare(key) == 0) {
+//       if(statement->child_block_.get() != nullptr) {
+//           value = *statement->child_block_;
+//           return true;
+//       }
+//       else {
+//         return false;
+//       }
+      
+//     }
+//   }
+//   return false;
+// }
 
 std::string NginxConfigStatement::ToString(int depth) {
   std::string serialized_statement;
@@ -169,7 +190,6 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
   while (true) {
     std::string token;
     token_type = ParseToken(config_file, &token);
-    printf ("%s: %s\n", TokenTypeAsString(token_type), token.c_str());
     if (token_type == TOKEN_TYPE_ERROR) {
       break;
     }

--- a/nginx-configparser/config_parser.h
+++ b/nginx-configparser/config_parser.h
@@ -22,7 +22,9 @@ class NginxConfig {
  public:
   std::string ToString(int depth = 0);
   std::vector<std::shared_ptr<NginxConfigStatement> > statements_;
-  virtual bool find(std::string& s);
+
+  virtual bool find(const std::string& key, std::string& value, int depth = 1);
+  bool find(const std::string& key, NginxConfig& value);
 };
 
 // The driver that parses a config file and generates an NginxConfig.

--- a/nginx-configparser/config_parser.h
+++ b/nginx-configparser/config_parser.h
@@ -24,7 +24,8 @@ class NginxConfig {
   std::vector<std::shared_ptr<NginxConfigStatement> > statements_;
 
   virtual bool find(const std::string& key, std::string& value, int depth = 1);
-  bool find(const std::string& key, NginxConfig& value);
+  virtual bool find(const std::string& key, NginxConfig& value);
+  virtual std::vector<std::shared_ptr<NginxConfigStatement> > findAll(const std::string& key);
 };
 
 // The driver that parses a config file and generates an NginxConfig.

--- a/nginx-configparser/config_parser_test.cc
+++ b/nginx-configparser/config_parser_test.cc
@@ -62,7 +62,7 @@ TEST_F(NginxStringConfigTest, findTest) {
   ASSERT_TRUE(ParseString("port 8000;")); 
   EXPECT_TRUE(out_config_.find("port", s));
   EXPECT_EQ(s, "8000");
-
+  EXPECT_FALSE(out_config_.find("port", s, 2));
   EXPECT_FALSE(out_config_.find("8000", s)); 
 }
 
@@ -189,7 +189,7 @@ TEST_F(NginxStringConfigTest, RealConfigExample) {
   ASSERT_NE(s1, nullptr);
   ASSERT_EQ(s0->ToString(0), "location /URL {\n  root /path/to/file;\n}\n");
   ASSERT_EQ(s1->ToString(0), "location /echo {\n  echo;\n}\n");
-  
+
   std::string path = "";
   EXPECT_TRUE(s0->child_block_.get()->find("root", path));
   EXPECT_EQ(path, "/path/to/file");

--- a/nginx-configparser/config_parser_test.cc
+++ b/nginx-configparser/config_parser_test.cc
@@ -56,16 +56,16 @@ TEST_F(NginxStringConfigTest, EmbeddedToString) {
 TEST_F(NginxStringConfigTest, findTest) {
   std::string s = "port";
   ASSERT_TRUE(ParseString("port 8000;")); 
-  EXPECT_TRUE(out_config_.find(s));
+  EXPECT_TRUE(out_config_.find("port", s));
   EXPECT_EQ(s, "8000");
 
-  EXPECT_FALSE(out_config_.find(s)); 
+  EXPECT_FALSE(out_config_.find("8000", s)); 
 }
 
 TEST_F(NginxStringConfigTest, findTestEmbeddedBlock) {
   std::string s = "port";
   ASSERT_TRUE(ParseString("server {\nport 8000;\n}")); 
-  EXPECT_FALSE(out_config_.find(s)); 
+  EXPECT_FALSE(out_config_.find("port", s)); 
 }
 
 
@@ -130,3 +130,5 @@ TEST_F(NginxStringConfigTest, SingleQuoteTest) {
   EXPECT_EQ(out_config_.statements_[0]->tokens_[0], "port");
   EXPECT_EQ(out_config_.statements_[0]->tokens_[1], "\'8000\'");
 }
+
+// TODO: ADD A CONFIG TEST WITH DUPLICATE BODIES.

--- a/nginx-configparser/config_parser_test.cc
+++ b/nginx-configparser/config_parser_test.cc
@@ -37,6 +37,10 @@ protected:
     std::stringstream config_stream(config_string);
     return parser_.Parse(&config_stream, &out_config_);
   }
+
+  bool FindConfig(const std::string key) {
+    return out_config_.find(key, out_config_);
+  }
   NginxConfigParser parser_;
   NginxConfig out_config_;
 };
@@ -122,6 +126,7 @@ TEST_F(NginxStringConfigTest, SimpleCommentConfig) {
 
 TEST_F(NginxStringConfigTest, ComplexCommentConfig) {
   EXPECT_TRUE(ParseString("server\n { server2 \n{ # test \ntestlisten 80;# test \n} \n}"));
+
 }
 
 
@@ -132,3 +137,64 @@ TEST_F(NginxStringConfigTest, SingleQuoteTest) {
 }
 
 // TODO: ADD A CONFIG TEST WITH DUPLICATE BODIES.
+
+TEST_F(NginxStringConfigTest, FindSubConfig) {
+  NginxConfig config;
+  std::string s = "";
+  ASSERT_TRUE(ParseString("port 3000;\necho {/URL; }"));
+  EXPECT_TRUE(out_config_.find("port", s));
+  EXPECT_EQ(s, "3000");
+  
+  EXPECT_TRUE(out_config_.find("echo", config));
+  EXPECT_EQ(config.ToString(), "/URL;\n");
+}
+
+
+TEST_F(NginxStringConfigTest, FindSubSubConfig) {
+  NginxConfig config;
+  NginxConfig sub_config;
+  std::string s = "";
+  ASSERT_TRUE(ParseString("port 3000;\necho { level2 { test; } }"));
+  EXPECT_TRUE(out_config_.find("port", s));
+  EXPECT_EQ(s, "3000");
+  
+  ASSERT_TRUE(out_config_.find("echo", config));
+  EXPECT_EQ(config.ToString(), "level2 {\n  test;\n}\n");
+  EXPECT_FALSE(config.find("port", s, 0));
+  EXPECT_TRUE(config.find("level2", s, 0));
+  EXPECT_FALSE(config.find("level2", s));
+
+  ASSERT_TRUE(config.find("level2", sub_config));
+  EXPECT_FALSE(sub_config.find("port", s));
+  EXPECT_FALSE(sub_config.find("test", s));
+  EXPECT_TRUE(sub_config.find("test", s, 0));
+  EXPECT_EQ(s, "test");
+}
+
+
+TEST_F(NginxStringConfigTest, RealConfigExample) {
+  NginxConfig config;
+  std::string s = "";
+  ASSERT_TRUE(ParseString("port 3000;\n\nlocation /URL {\n    root /path/to/file;\n}\n\nlocation /echo {\n    echo;\n}\n"));
+  printf("port 3000;\n\nlocation /URL {\n    root /path/to/file;\n}\n\nlocation /echo {\n    echo;\n}\n");
+  EXPECT_TRUE(out_config_.find("port", s));
+  EXPECT_EQ(s, "3000");
+  
+
+  std::vector<std::shared_ptr<NginxConfigStatement> > statements = out_config_.findAll("location");
+  ASSERT_EQ(statements.size(), 2);
+  NginxConfigStatement* s0 = statements[0].get();
+  NginxConfigStatement* s1 = statements[1].get();
+  ASSERT_NE(s0, nullptr);
+  ASSERT_NE(s1, nullptr);
+  ASSERT_EQ(s0->ToString(0), "location /URL {\n  root /path/to/file;\n}\n");
+  ASSERT_EQ(s1->ToString(0), "location /echo {\n  echo;\n}\n");
+  
+  std::string path = "";
+  EXPECT_TRUE(s0->child_block_.get()->find("root", path));
+  EXPECT_EQ(path, "/path/to/file");
+
+  EXPECT_FALSE(s0->child_block_.get()->find("echo", path, 0));
+  EXPECT_TRUE(s1->child_block_.get()->find("echo", path, 0));
+  EXPECT_EQ(path, "echo");
+}

--- a/test_config
+++ b/test_config
@@ -1,1 +1,9 @@
 port 3000;
+
+location /URL {
+    root /path/to/file;
+}
+
+location /echo {
+    echo;
+}

--- a/webserver.cc
+++ b/webserver.cc
@@ -11,21 +11,19 @@ bool Webserver::run_server(const char* file_name){
   }
 
 
-  std::string port_str = "port";
-  
-  if (!config_->find(port_str)) {
+  std::string port_str = "";
+  if (!config_->find("port", port_str, 1)) {
     printf("Config does not specify a port");
     return false;
   }
-  
+
   int port = std::atoi(port_str.c_str());
   if(port < 1024 || port > 65535) {
     printf("Invalid port %d", port);
     return 1;
   }
   
-  try {
-
+  try { // this is a terrible idea. NO EXCEPTIONS. 
     boost::asio::io_service io_service;
     Server s(io_service, port);
     printf("Running server on port %s...\n", port_str.c_str());

--- a/webserver_test.cc
+++ b/webserver_test.cc
@@ -9,6 +9,7 @@
 using ::testing::Return;
 using ::testing::_;
 using ::testing::SetArgReferee;
+using ::testing::An;
 
 
 class MockConfigParser: public NginxConfigParser{
@@ -19,7 +20,14 @@ public:
 
 class MockNginxConfig: public NginxConfig{
 public:
-	MOCK_METHOD1(find,bool(std::string& s));
+  bool find(const std::string& key, std::string& value, int depth = 1) {
+    return mocked_find(key, value, depth);
+  }
+  bool find(const std::string& key, NginxConfig& value) {
+    return mocked_find(key, value);
+  }
+	MOCK_METHOD3(mocked_find,bool(const std::string& key, std::string& value, int depth));  
+  MOCK_METHOD2(mocked_find,bool(const std::string& key, NginxConfig& value));
 };
 
 TEST(WebserverTest, ConfigurationFail) {
@@ -30,10 +38,10 @@ TEST(WebserverTest, ConfigurationFail) {
   std::string dummy_file = "dummy";
   
   EXPECT_CALL(mock_parser, Parse(dummy_file.c_str(), _))
-    .WillOnce(
-     
-      Return(false));
-  EXPECT_CALL(mock_config, find(_)).Times(0);
+    .WillOnce( 
+      Return(false)
+    );
+  EXPECT_CALL(mock_config, mocked_find("port", An<std::string &>(), An<int>())).Times(0);
   EXPECT_FALSE(server.run_server(dummy_file.c_str()));
 }
 
@@ -47,10 +55,12 @@ TEST(WebserverTest, FindPortFail) {
   
   EXPECT_CALL(mock_parser, Parse(dummy_file.c_str(), _))
     .WillOnce(
-     
-      Return(true));
-  EXPECT_CALL(mock_config, find(_)).WillOnce(
-  	  Return(false)	);
+      Return(true)
+    );
+  EXPECT_CALL(mock_config, mocked_find("port", An<std::string &>(), An<int>()))
+    .WillOnce(
+  	  Return(false)	
+    );
   EXPECT_FALSE(server.run_server(dummy_file.c_str()));
 }
 


### PR DESCRIPTION
Added functionality and refactored API on the config parser.
* Find now takes in two strings (and an optional third parameter for depth).
  * The first string is the key to search over, the value is in the second key, and the depth is where to look for the value. Returns true if a value is found
* find now supports nginx-configs
  * Takes in a key as the first paramter, and takes in a nginx-config as the second parameter. Sets the value of the second parameter if a value is found. Returns true if a value is found.
* findAll added
  * Takes in a key as the only parameter. Returns a vector of NginxConfigStatement shared pointers. (API mismatch? Should consider this. However, changing it to actual NginxConfig's would be more inefficient as it would involve having a copy constructor/restructuring privates).